### PR TITLE
Fixed tool.setuptools.packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,13 @@ Homepage = "https://github.com/BatteRaquette581/talkomatic.py/"
 Issues = "https://github.com/BatteRaquette581/talkomatic.py/issues/"
 
 [tool.setuptools]
-packages = ["talkomatic"]
+packages = [
+    "talkomatic",
+    "talkomatic.api",
+    "talkomatic.api.v1",
+    "talkomatic.commands",
+    "talkomatic.dataclasses"
+]
 
 [tool.setuptools.dynamic]
 dependencies = { file = "requirements.txt" }


### PR DESCRIPTION
All talkomatic submodules are now properly included in the build.